### PR TITLE
Add pip packaging (scikit-build-core) and an ASE neighbour-list plugin

### DIFF
--- a/language_bindings/python/CMakeLists.txt
+++ b/language_bindings/python/CMakeLists.txt
@@ -19,3 +19,11 @@ target_link_libraries(_matscipy_neighbours PRIVATE neighbours Python::NumPy)
 set_target_properties(_matscipy_neighbours PROPERTIES
     LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}"
 )
+
+# Install the extension *inside* the Python package so the relative import
+# `from . import _matscipy_neighbours` (matscipy_neighbours/neighbours.py)
+# resolves in an installed wheel.  Used by the scikit-build-core packaging
+# (see the repository-root pyproject.toml).
+install(TARGETS _matscipy_neighbours
+        LIBRARY DESTINATION matscipy_neighbours
+        RUNTIME DESTINATION matscipy_neighbours)

--- a/language_bindings/python/matscipy_neighbours/_ase_plugin.py
+++ b/language_bindings/python/matscipy_neighbours/_ase_plugin.py
@@ -1,0 +1,50 @@
+"""ASE v4 neighbour-list plugin for matscipy-neighbours.
+
+Registers the compiled neighbour list as an ``ase.plugins`` backend, so it can
+be selected *explicitly* via :func:`ase.neighborlist.get_neighbor_list` (or, in
+due course, a calculator's ``neighbor_list=`` option).  Selection is never
+automatic -- this only makes the backend *available* under the name
+``"matscipy-neighbours"``.
+
+This module is the ``ase.plugins`` entry point (it exposes ``__ase_plugins__``).
+The registration is guarded so that installing this package alongside an ASE
+that predates the v4 plugin API registers nothing rather than breaking plugin
+discovery.  The heavy import of the compiled extension happens lazily, inside
+the adapter, so merely building the plugin collection does not import it.
+"""
+from __future__ import annotations
+
+
+def neighbor_list(quantities, atoms, cutoff, *, self_interaction=False):
+    """matscipy-neighbours neighbour list adapted to ASE's protocol.
+
+    ``matscipy_neighbours.neighbour_list`` returns the same ``(i, j, d, D, S)``
+    flat arrays and quantity letters as ``ase.neighborlist.neighbor_list`` but
+    has no ``self_interaction`` option (it never returns pure self-pairs).  Per
+    the plugin contract a request it cannot honour is rejected rather than
+    silently differing, so ``self_interaction=True`` raises.
+    """
+    if self_interaction:
+        raise NotImplementedError(
+            'the matscipy-neighbours backend does not support '
+            'self_interaction=True')
+    from matscipy_neighbours import neighbour_list as _neighbour_list
+
+    return _neighbour_list(quantities, atoms, cutoff)
+
+
+try:
+    from ase._4.plugins.neighborlist import NeighborListPlugin
+except ImportError:
+    # ASE without the v4 plugin API: register nothing, but do not break the
+    # discovery of other plugins.
+    __ase_plugins__: set = set()
+else:
+    __ase_plugins__ = {
+        NeighborListPlugin(
+            'matscipy-neighbours',
+            long_name='matscipy-neighbours compiled neighbour list',
+            citation='https://github.com/libAtoms/matscipy-neighbours',
+            implementation='matscipy_neighbours._ase_plugin.neighbor_list',
+        ),
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["scikit-build-core>=0.10", "numpy"]
+build-backend = "scikit_build_core.build"
+
+[project]
+name = "matscipy-neighbours"
+version = "0.1.0"
+description = "Neighbour list for particle simulations"
+readme = "README.md"
+license = { file = "LICENSE.md" }
+requires-python = ">=3.10"
+dependencies = ["numpy"]
+
+[project.optional-dependencies]
+# ASE is optional: only needed for Atoms input and element-pair cutoffs.
+ase = ["ase"]
+
+[project.urls]
+repository = "https://github.com/libAtoms/matscipy-neighbours"
+
+# Expose the compiled neighbour list as an ASE v4 neighbour-list backend.
+[project.entry-points."ase.plugins"]
+matscipy_neighbours = "matscipy_neighbours._ase_plugin"
+
+[tool.scikit-build]
+# Pure-Python package lives under language_bindings/python; the compiled
+# extension is installed into it by the CMake install() rule (see
+# language_bindings/python/CMakeLists.txt) so the package's relative import
+# `from . import _matscipy_neighbours` resolves.
+wheel.packages = ["language_bindings/python/matscipy_neighbours"]
+# CPU-only wheel: skip the C++ test/benchmark/example targets (the tests fetch
+# GoogleTest from the network). GPU is a separate, documented build
+# (-Dcmake.define.ENABLE_CUDA=ON).
+cmake.args = [
+    "-DBUILD_TESTING=OFF",
+    "-DBUILD_BENCHMARKS=OFF",
+    "-DBUILD_EXAMPLES=OFF",
+]


### PR DESCRIPTION
## Summary

Makes `matscipy-neighbours` **pip-installable** and registers its neighbour list as an **ASE neighbour-list backend**, so:

```sh
pip install .          # builds the C extension into a wheel
```
```python
from ase.neighborlist import get_neighbor_list, available_neighbor_list_backends
available_neighbor_list_backends()        # {'ase': True, 'matscipy-neighbours': True, ...}
nl = get_neighbor_list("matscipy-neighbours")
i, j, d, D, S = nl("ijdDS", atoms, 5.0)
```

Selection is **explicit and never automatic** — this only makes the backend *available* under the name `matscipy-neighbours`.

## What's here

- **`pyproject.toml`** (new) — a [scikit-build-core](https://scikit-build-core.readthedocs.io/) build backend driving the existing CMake. Builds a **CPU-only** wheel by default (`BUILD_TESTING`/`BUILD_BENCHMARKS`/`BUILD_EXAMPLES` off, so the GoogleTest fetch is skipped); GPU stays an explicit opt-in (`-C cmake.define.ENABLE_CUDA=ON` / `ENABLE_HIP=ON`). Declares the `ase.plugins` entry point. `ase` is an optional extra.
- **`language_bindings/python/CMakeLists.txt`** — adds an `install(TARGETS _matscipy_neighbours … DESTINATION matscipy_neighbours)` rule so the extension lands *inside* the package in the wheel; the existing relative-import fallback in `neighbours.py` (`from . import _matscipy_neighbours`) then resolves with no source change.
- **`language_bindings/python/matscipy_neighbours/_ase_plugin.py`** (new) — a thin adapter matching ASE's `NeighborListFunction` contract. `neighbour_list` already returns the same `(i, j, d, D, S)` letters and `D = r[j]-r[i]+S@cell`; the adapter only adds the `self_interaction` keyword, rejecting `self_interaction=True` (unsupported by the kernel) rather than silently differing.

## Notes

- Targets ASE's in-flight **v4 plugin system** (the `ase.plugins` entry-point group + `NeighborListPlugin`). The `__ase_plugins__` registration is **guarded** — on an ASE without that API it registers nothing instead of breaking plugin discovery — so this is safe to merge ahead of the ASE side landing, and a no-op for current released ASE.
- `version = "0.1.0"` is a static placeholder (the repo has no version metadata today); maintainers may prefer a dynamic/scm version.

## Validation

Built and installed with `pip install .` (cp312 wheel, extension installed inside the package). Against an ASE branch carrying the v4 `NeighborListPlugin`: `matscipy-neighbours` edge sets are byte-identical to ASE's reference backend across fcc / hcp / mixed-pbc slab systems (cutoffs 3 and 5 Å; `D` agrees to ~1e-15). In a neighbour-list backend benchmark it was the fastest CPU backend measured (e.g. ~3× faster than `matscipy.neighbours` and ~55× faster than ASE's default at 108k atoms) with the lowest peak memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)